### PR TITLE
Improve behavior in the small-r region

### DIFF
--- a/src/dipole.cpp
+++ b/src/dipole.cpp
@@ -64,7 +64,7 @@ int Dipole::InitializeInterpolation(int yind)
         delete dipole_interp;
     }
 
-    dipole_interp = new Interpolator(rvals, amplitude[yind]);
+    dipole_interp = new Interpolator(rvals, amplitude[yind],LOG_INTERPOLATOR);
     dipole_interp->SetUnderflow(0);
     dipole_interp->SetOverflow(1.0);
     dipole_interp->SetFreeze(true);
@@ -159,6 +159,7 @@ double Dipole::InterpolateN(double r, double y)
     
     // Now we know that yind and yind+1 are acceptable indeces, so we can interpolate in rapidity linearly
     // Construct interpolators in r at both rapidities
+    /*
     std::vector<double> rvals_lower;
     std::vector<double> rvals_upper;
     std::vector<double> nvals_lower;
@@ -191,7 +192,9 @@ double Dipole::InterpolateN(double r, double y)
     if (result > 1.0) return 1.0;
     if (result < 0) return 0;
     
+    
     return result;
+    */
 }
 
 /*

--- a/src/mv.cpp
+++ b/src/mv.cpp
@@ -57,13 +57,11 @@ cout << r<< " " << res << endl;
 	if (r < 1e-30)
 		return 0;
 	const double e = 2.7182818;
-	///TODO: some algorithm to determina small r, e.g. when one has to linearize
-    if (r < 2e-6)   ///NOTE: factor 1/4 "correctly", not as in AAMS paper
-            return std::pow(SQR(r)*qs0sqr, anomalous_dimension)/4.0
-            * std::log( 1.0/(r*lambdaqcd) + ec*e) ;
-    return 1.0 - std::exp(-std::pow(SQR(r)*qs0sqr, anomalous_dimension)/4.0
-            * std::log( 1.0/(r*lambdaqcd) + ec*e) );
-}
+	double exponent = std::pow(SQR(r)*qs0sqr, anomalous_dimension)/4.0
+		* std::log( 1.0/(r*lambdaqcd) + ec*e);
+	if (exponent < 1e-5) return exponent;
+	else return 1.0 - std::exp(-exponent);
+
 
 
 void MV::SetQsqr(double qsqr)

--- a/src/nlobk_config.hpp
+++ b/src/nlobk_config.hpp
@@ -111,6 +111,8 @@ namespace config
     extern KINEMATICAL_CONSTRAINTS KINEMATICAL_CONSTRAINT; // Solve nonlocal kinematically constrained BK (LO part)
     
     extern bool EULER_METHOD;    // Use Euler method instead of Runge Kutta, must be true if KINEMATICA_CONSTRAINT is used
+
+    const bool LOG_INTERPOLATOR = true; // Flag to determine if interpolate the dipole in log(r), log(N) 
     
 }
 std::string NLOBK_CONFIG_STRING();


### PR DESCRIPTION
* Modified MV model parametrization now works better in the region where the dipole amplitude is very small
* Smaller absolute error now required in the DE solver. If the code is too small, see solver.cpp line 90
* By default interpolate the dipole in the log(r),log(N) grid. This behavior is controlled by the LOG_INTERPOLATOR flag in nlobk_config.hpp